### PR TITLE
Restore versioning

### DIFF
--- a/dictionaryutils/docker/run_tests.sh
+++ b/dictionaryutils/docker/run_tests.sh
@@ -16,6 +16,18 @@ source /app/venvs/dict/bin/activate
 # Define the host directory to mount
 HOST_DIR="/mnt/host"
 
+# Add global config to avoid fatal security error
+git config --global --add safe.directory $HOST_DIR
+
+# Try to get commit and tag information from git
+if [[ -d $HOST_DIR/.git && -d $HOST_DIR/gdcdictionary ]]; then
+  (
+    cd $HOST_DIR
+    DICTCOMMIT=`git rev-parse HEAD` && echo "DICTCOMMIT=\"${DICTCOMMIT}\"" >/app/dictionaryutils/version_data.py
+    DICTVERSION=`git describe --always --tags` && echo "DICTVERSION=\"${DICTVERSION}\"" >>/app/dictionaryutils/version_data.py
+  )
+fi
+
 # Copy YAML files from the host directory to the container's schema directory
 SCHEMA_DIR=$(python -c "from gdcdictionary import SCHEMA_DIR; print(SCHEMA_DIR)")
 #echo $SCHEMA_DIR


### PR DESCRIPTION
This commit restores versioning output to the `run_tests.sh` script that outputs a `schema.json` file. It tries to find a commit and tag, and then writes those out to the `version_data.py` file that the `dump_schema.py` script uses to output the JSON file. This embeds the version info in the `_settings.yaml` section of the schema file, which can then be used by the portal to display the version of the dictionary in use.